### PR TITLE
Update eink-1.yaml

### DIFF
--- a/esphome/eink-1.yaml
+++ b/esphome/eink-1.yaml
@@ -307,15 +307,7 @@ online_image:
 display:
   - platform: epaper_spi
     id: epaper_display
-    model: 7.3in-spectra-e6
-    cs_pin: GPIO10
-    dc_pin: GPIO11
-    reset_pin:
-      number: GPIO12
-      inverted: false
-    busy_pin:
-      number: GPIO13
-      inverted: true
+    model: Seeed-reTerminal-E1002
     update_interval: never
     lambda: |-
       // Draw the dashboard image first


### PR DESCRIPTION
Update display config to work with ESPHome 2025.12:

Tried the existing code and the display would not update. 
Reviewed other documentation from SEEED [here](https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/), and found their display config is different for the color display. After changing the model type alone and testing, it didn't work. 
It did refresh my display after I removed the pin designations.
This change is the total fix to make the E1002 work with the current ESPHome build 2025.12.
